### PR TITLE
[TASK] removed using of deprecated SpriteManager in TYPO3 7

### DIFF
--- a/Classes/Toolbar/ToolbarItem.php
+++ b/Classes/Toolbar/ToolbarItem.php
@@ -39,7 +39,7 @@ class ToolbarItem implements \TYPO3\CMS\Backend\Toolbar\ClearCacheActionsHookInt
 				'id'    => self::$itemKey,
 				'title' => $this->getLanguageService()->sL('LLL:EXT:flush_language_cache/Resources/Private/Language/locallang.xlf:flushLanguageCache'),
 				'href'  => BackendUtility::getAjaxUrl('language_cache::flushCache'),
-				'icon'  => IconUtility::getSpriteIcon('extensions-flush_language_cache-flush_cache')
+				'icon'  => $this->getLanguageFlushCacheIcon()
 			);
 			$optionValues[] = self::$itemKey;
 		}
@@ -72,5 +72,17 @@ class ToolbarItem implements \TYPO3\CMS\Backend\Toolbar\ClearCacheActionsHookInt
 	 */
 	protected function getLanguageService() {
 		return $GLOBALS['LANG'];
+	}
+
+	/**
+	 * @return string Icon MarkUp
+	 */
+	public function getLanguageFlushCacheIcon() {
+		if (version_compare(TYPO3_version, '7.6', '>=')) {
+			$iconFactory = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Imaging\\IconFactory');
+			return $iconFactory->getIcon('extensions-flush_language_cache-flush_cache', \TYPO3\CMS\Core\Imaging\Icon::SIZE_SMALL)->render();
+		}else{
+			return IconUtility::getSpriteIcon('extensions-flush_language_cache-flush_cache');
+		}
 	}
 }

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -3,12 +3,28 @@ if (!defined ('TYPO3_MODE')) {
 	die ('Access denied.');
 }
 
-\TYPO3\CMS\Backend\Sprite\SpriteManager::addSingleIcons(
-	array(
-		'flush_cache' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY) . 'Resources/Public/Images/FlushCache.png'
-	),
-	$_EXTKEY
-);
+
+if (version_compare(TYPO3_version, '7.6', '>=')) {
+    /** @var \TYPO3\CMS\Core\Imaging\IconRegistry $iconRegistry */
+    $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Imaging\\IconRegistry');
+    $iconRegistry->registerIcon('extensions-' . $_EXTKEY . '-flush_cache',
+        'TYPO3\\CMS\\Core\\Imaging\\IconProvider\\BitmapIconProvider',
+        array(
+            'source' => 'EXT:' . $_EXTKEY . '/Resources/Public/Images/FlushCache.png',
+        )
+    );
+    unset($iconRegistry);
+} else {
+
+    \TYPO3\CMS\Backend\Sprite\SpriteManager::addSingleIcons(
+        array(
+            'flush_cache' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath($_EXTKEY) . 'Resources/Public/Images/FlushCache.png'
+        ),
+        $_EXTKEY
+    );
+}
+
+
 
 // Register additional clear cache menu item
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['additionalBackendItems']['cacheActions']['flushLanguageCache'] = 'Cobweb\\FlushLanguageCache\\Toolbar\\ToolbarItem';


### PR DESCRIPTION
Hi François,

i got some deprecation notifications in TYPO3 7 like this one

> TYPO3\CMS\Backend\Utility\IconUtility::getSpriteIcon() - since TYPO3 CMS 7, will be removed with TYPO3 CMS 8, use IconFactory->getIcon instead 

With the pull request your extension should still be running in TYPO3 6 and 7.

Best Regards
Sven
