### PR TITLE
Migration for TYPO3 9.5 LTS

### DIFF
--- a/Classes/Command/FlushLanguageCacheCommand.php
+++ b/Classes/Command/FlushLanguageCacheCommand.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Cobweb\FlushLanguageCache\Command;
 
 /**
@@ -28,16 +29,16 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class FlushLanguageCacheCommand extends Command
 {
-
     /**
      * Configures the command by setting its name, description and options.
      *
      * @return void
      */
-    public function configure()
+    public function configure(): void
     {
-        $this->setDescription('Clears the language cache (l10n).')
-                ->setHelp('Just run the command and the whole language cache will be cleared.');
+        $this
+            ->setDescription('Clears the language cache (l10n).')
+            ->setHelp('Just run the command and the whole language cache will be cleared.');
     }
 
     /**
@@ -48,7 +49,7 @@ class FlushLanguageCacheCommand extends Command
      *
      * @return void
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): void
     {
         /** @var \TYPO3\CMS\Core\Cache\Frontend\FrontendInterface $cacheFrontend */
         $cacheFrontend = GeneralUtility::makeInstance(CacheManager::class)->getCache('l10n');

--- a/Classes/Controller/FlushCacheController.php
+++ b/Classes/Controller/FlushCacheController.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+namespace Cobweb\FlushLanguageCache\Controller;
+
+/**
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class FlushCacheController
+ * @package Cobweb\FlushLanguageCache\Controller
+ */
+class FlushCacheController
+{
+    /**
+     * Main dispatcher entry method registered as "flushLanguageCache" end point
+     * Flushes the language cache (l10n).
+     *
+     * @param ServerRequestInterface $request the current request
+     * @param ResponseInterface $response the current response
+     * @return ResponseInterface
+     */
+    public function flushCache(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        /** @var \TYPO3\CMS\Core\Cache\Frontend\FrontendInterface $cacheFrontend */
+        $cacheFrontend = GeneralUtility::makeInstance(CacheManager::class)->getCache('l10n');
+        $cacheFrontend->flush();
+
+        $response->getBody()->write('');
+        return $response;
+    }
+}

--- a/Classes/Toolbar/ToolbarItem.php
+++ b/Classes/Toolbar/ToolbarItem.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 namespace Cobweb\FlushLanguageCache\Toolbar;
 
 /**
@@ -16,8 +17,9 @@ namespace Cobweb\FlushLanguageCache\Toolbar;
 
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Toolbar\ClearCacheActionsHookInterface;
-use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 
 /**
  * Prepares additional flush cache entry.
@@ -25,8 +27,9 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @package Cobweb\ClearLanguageCache\Toolbar
  * @author Francois Suter <support@cobweb.ch>
  */
-class ToolbarItem implements ClearCacheActionsHookInterface {
-	static public $itemKey = 'flushLanguageCache';
+class ToolbarItem implements ClearCacheActionsHookInterface
+{
+	const ITEM_KEY = 'flushLanguageCache';
 
 	/**
 	 * Adds the flush language cache menu item.
@@ -35,43 +38,37 @@ class ToolbarItem implements ClearCacheActionsHookInterface {
 	 * @param array $optionValues Array of AccessConfigurations-identifiers (typically used by userTS with options.clearCache.identifier)
 	 * @return void
 	 */
-	public function manipulateCacheActions(&$cacheActions, &$optionValues) {
-        if ($this->getBackendUser()->isAdmin() || $this->getBackendUser()->getTSConfigVal('options.clearCache.flushLanguageCache')) {
+	public function manipulateCacheActions(&$cacheActions, &$optionValues): void
+    {
+        $backEndUser = $this->getBackendUser();
+        $userTsConfig = $backEndUser->getTSConfig();
+
+        if ($backEndUser->isAdmin() || (bool)$userTsConfig['options.']['clearCache.']['flushLanguageCache'] ?? false) {
             /** @var UriBuilder $uriBuilder */
             $uriBuilder = GeneralUtility::makeInstance(UriBuilder::class);
             try {
-                $uri = $uriBuilder->buildUriFromRoute('ajax_tx_flushlanguagecache_clear');
+                $uri = $uriBuilder->buildUriFromRoute('flushLanguageCache');
                 $cacheActions[] = [
-                    'id' => self::$itemKey,
+                    'id' => static::ITEM_KEY,
                     'title' => 'LLL:EXT:flush_language_cache/Resources/Private/Language/locallang.xlf:flushLanguageCache',
                      'description' => 'LLL:EXT:flush_language_cache/Resources/Private/Language/locallang.xlf:flushLanguageCache.description',
                     'href' => $uri,
                     'iconIdentifier'  => 'tx_flushlanguagecache_flush'
                 ];
-                $optionValues[] = self::$itemKey;
-            } catch (\TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException $e) {
+                $optionValues[] = static::ITEM_KEY;
+            } catch (RouteNotFoundException $e) {
                 // Do nothing, i.e. do not add the menu item if the AJAX route cannot be found
             }
 		}
 	}
 
 	/**
-	 * Flushes the language cache (l10n).
-	 *
-	 * @return void
-	 */
-	public function flushCache() {
-		/** @var \TYPO3\CMS\Core\Cache\Frontend\FrontendInterface $cacheFrontend */
-		$cacheFrontend = GeneralUtility::makeInstance(CacheManager::class)->getCache('l10n');
-		$cacheFrontend->flush();
-	}
-
-	/**
 	 * Wrapper around the global BE user object.
 	 *
-	 * @return \TYPO3\CMS\Core\Authentication\BackendUserAuthentication
+	 * @return BackendUserAuthentication
 	 */
-	protected function getBackendUser() {
+	protected function getBackendUser(): BackendUserAuthentication
+    {
 		return $GLOBALS['BE_USER'];
 	}
 }

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -1,8 +1,0 @@
-<?php
-
-return [
-        'tx_flushlanguagecache_clear' => [
-                'path' => '/flush_language_cache/clear',
-                'target' => \Cobweb\FlushLanguageCache\Toolbar\ToolbarItem::class . '::flushCache'
-        ]
-];

--- a/Configuration/Backend/Routes.php
+++ b/Configuration/Backend/Routes.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'flushLanguageCache' => [
+            'path' => '/flush_language_cache/clear',
+            'target' => \Cobweb\FlushLanguageCache\Controller\FlushCacheController::class . '::flushCache'
+    ]
+];

--- a/Configuration/Commands.php
+++ b/Configuration/Commands.php
@@ -1,6 +1,6 @@
 <?php
 return [
-        'languagecache:flush' => [
-                'class' => \Cobweb\FlushLanguageCache\Command\FlushLanguageCacheCommand::class
-        ]
+    'languagecache:flush' => [
+            'class' => \Cobweb\FlushLanguageCache\Command\FlushLanguageCacheCommand::class
+    ]
 ];

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ flushing only the language cache (``l10n``). This way you can avoid flushing the
 whole system cache when updating just a couple of localized strings (in locallang
 files).
 
-This extension requires TYPO3 CMS 8.7 or more.
+This extension requires TYPO3 CMS 9.5 or more.
 
 Just install it and flush the system cache. Reload the backend and the new
 item will appear in the flush cache menu.

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,8 @@
 			"Cobweb\\FlushLanguageCache\\": "Classes/"
 		}
 	},
-	"version": "2.0.0",
 	"require": {
-		"typo3/cms-core": ">=8.7.0,<10.0"
+		"typo3/cms-core": "^9.5"
 	},
 	"replace": {
 		"flush_language_cache": "self.version",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -8,31 +8,23 @@
 * https://github.com/t3elmar/Ext
 *********************************************************************/
 
-$EM_CONF[$_EXTKEY] = array (
-  'title' => 'Flush language cache',
-  'description' => 'Adds an item to the flush cache menu to clear just the language (l10n) cache. Also provides a command-line tool for that.',
-  'category' => 'be',
-  'state' => 'stable',
-  'uploadfolder' => 0,
-  'createDirs' => '',
-  'clearCacheOnLoad' => 1,
-  'author' => 'Francois Suter',
-  'author_email' => 'typo3@cobweb.ch',
-  'author_company' => '',
-  'version' => '2.0.0',
-  'constraints' =>
-  array (
-    'depends' =>
-    array (
-      'typo3' => '8.7.0-9.99.99',
-    ),
-    'conflicts' =>
-    array (
-    ),
-    'suggests' =>
-    array (
-    ),
-  ),
-);
-
-?>
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'Flush language cache',
+    'description' => 'Adds an item to the flush cache menu to clear just the language (l10n) cache. Also provides a command-line tool for that.',
+    'category' => 'be',
+    'state' => 'stable',
+    'uploadfolder' => 0,
+    'createDirs' => '',
+    'clearCacheOnLoad' => 1,
+    'author' => 'Francois Suter',
+    'author_email' => 'typo3@cobweb.ch',
+    'author_company' => '',
+    'version' => '2.1.0',
+    'constraints' => [
+        'depends' => [
+            'typo3' => '9.5.0-9.5.99',
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+];

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,18 +1,18 @@
 <?php
-if (!defined ('TYPO3_MODE')) {
-	die ('Access denied.');
-}
+defined('TYPO3_MODE') or die();
 
-// Register sprite icon for clear cache menu
-/** @var \TYPO3\CMS\Core\Imaging\IconRegistry $iconRegistry */
-$iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
-$iconRegistry->registerIcon(
+(function () {
+    // Register sprite icon for clear cache menu
+    /** @var \TYPO3\CMS\Core\Imaging\IconRegistry $iconRegistry */
+    $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
+    $iconRegistry->registerIcon(
         'tx_flushlanguagecache_flush',
         \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
         [
                 'source' => 'EXT:flush_language_cache/Resources/Public/Icons/FlushCache.svg'
         ]
-);
+    );
 
-// Register additional clear cache menu item
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['additionalBackendItems']['cacheActions']['flushLanguageCache'] = \Cobweb\FlushLanguageCache\Toolbar\ToolbarItem::class;
+    // Register additional clear cache menu item
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['additionalBackendItems']['cacheActions']['flushLanguageCache'] = \Cobweb\FlushLanguageCache\Toolbar\ToolbarItem::class;
+})();


### PR DESCRIPTION
Remove false error after caches being cleared. Refactoring, TYPO3 8.7 support drop.
Version was set to 2.1.0